### PR TITLE
Add secure TOTP generation

### DIFF
--- a/src/backend.js
+++ b/src/backend.js
@@ -72,4 +72,20 @@ app.post('/get_secrets', function (req, res) {
     .then(user_secrets => res.send({ success: true, secrets: user_secrets }))
 })
 
+app.post('/get_totp', function (req, res) {
+  database.models.user_secret
+    .findOne({
+      where: {
+        userUserId: req.body.user_id,
+        secretSecretId: req.body.secret_id
+      },
+      include: [database.models.secret]
+    })
+    .then(user_secret =>
+      user_secret.secret.getTOTP(totp =>
+        res.send({ success: true, totp: totp })
+      )
+    )
+})
+
 app.listen(port, () => console.log(`Example app listening on port ${port}!`))

--- a/src/components/OTPGenerator.js
+++ b/src/components/OTPGenerator.js
@@ -1,30 +1,41 @@
-import React from 'react';
-import { Component } from 'react';
-import { TOTP } from '@akanass/rx-otp';
+import React from 'react'
+import { Component } from 'react'
 
 class OTPGenerator extends Component {
-    constructor(props){
-      super(props);
-      this.state = { current_token : null, time: Date.now(), secret: props.secret };
-    }
-    componentDidMount() {
-      this.interval = setInterval(() =>
-        TOTP.generate(this.state.secret, { code_digits: 6, algorithm: 'SHA1' })
-            .subscribe(token => this.setState({ current_token: token, time: Date.now() }) ),
-      500);
-    }
-    componentWillUnmount() {
-      clearInterval(this.interval);
-    }
-    render () {
-      return (
-        <div className="OTPGenerator">
-          <p>
-            {this.state.current_token}
-          </p>
-        </div>
-      )
+  constructor (props) {
+    super(props)
+    this.state = {
+      current_token: null
     }
   }
+  componentDidMount () {
+    this.interval = setInterval(
+      () =>
+        fetch('/get_totp', {
+          method: 'POST',
+          body: JSON.stringify({
+            user_id: this.props.current_user_id,
+            secret_id: this.props.secret_id
+          }),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }).then(res =>
+          res.json().then(data => this.setState({ current_token: data.totp }))
+        ),
+      3000
+    )
+  }
+  componentWillUnmount () {
+    clearInterval(this.interval)
+  }
+  render () {
+    return (
+      <div className='OTPGenerator'>
+        <p>{this.state.current_token}</p>
+      </div>
+    )
+  }
+}
 
-export default OTPGenerator;
+export default OTPGenerator

--- a/src/models/secret.js
+++ b/src/models/secret.js
@@ -35,17 +35,17 @@ module.exports = (sequelize, DataTypes) => {
       sequelize
     }
   )
-  Secret.prototype._unsafeGetSecret = function (success_callback) {
+  Secret.prototype._unsafeGetTOTP = function (success_callback) {
     TOTP.generate(this.getDataValue('secret')).subscribe(success_callback)
   }
-  Secret.prototype.getSecret = function (
+  Secret.prototype.getTOTP = function (
     success_callback,
     mfa_token,
     user_secret
   ) {
     this.getDataValue('secure')
-      ? user_secret.verify(mfa_token, this._unsafeGetSecret(success_callback))
-      : this._unsafeGetSecret(success_callback)
+      ? user_secret.verify(mfa_token, this._unsafeGetTOTP(success_callback))
+      : this._unsafeGetTOTP(success_callback)
   }
   return Secret
 }

--- a/src/views/Secret.js
+++ b/src/views/Secret.js
@@ -16,7 +16,7 @@ class SecretView extends React.Component {
     return (
       <div className='secretView'>
         <h2>{this.props.name}</h2>
-        {/* <OTPGenerator secret={this.props.secret}/> */}
+        <OTPGenerator secret_id={this.props.secret_id} {...this.props} />
         {details}
       </div>
     )

--- a/src/views/UserSecrets.js
+++ b/src/views/UserSecrets.js
@@ -29,7 +29,7 @@ class UserSecrets extends React.Component {
         <header className='UserSecrets-header'>
           <h1>Your Secrets</h1>
           {this.state.secrets.map(s => (
-            <SecretView {...s} />
+            <SecretView {...s} {...this.props} />
           ))}
           <h2>Create Secret</h2>
           {<CreateSecret parent={this} {...this.props} />}


### PR DESCRIPTION
**Functionality**

- [ ] Settings to decide whether or not to make a MFA secret secure
- [ ] If a secret is secure, show a user a MFA consumer secret (linked to a user_secret) once, they can only access the MFA secret if they give group2fa the MFA TOTP for that user_secret
- [ ] If a secret is not secure, they can view the MFA secret if they are logged in
- [ ] Add the ability to add/remove users to secrets
- [ ] Add the ability to delete secrets
- [ ] Add the ability to audit secrets